### PR TITLE
Converted remainder of pieces to custom pieces with move lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Adding an screenshot or a mockup of your application in action would be nice.
 3. Double-click the executable (or enter its path name in a terminal) to start the game.
 4. Use the mouse to interact with the in-game window.
 ### How to build
+You will need more than 630 MB of free disk space, excluding this project itself.
 1. Run the Godot Engine v3.5.1.
-    - Download the archive for your operating system. ([GodotEngine.org](https://godotengine.org/download) | [GitHub Releases](https://github.com/godotengine/godot/releases/tag/3.5.1-stable))
+    - Download the archive for your operating system from [GodotEngine.org](https://godotengine.org/download) or [GitHub Releases](https://github.com/godotengine/godot/releases/tag/3.5.1-stable). Download size and total size are each less than 100 MB.
     - Extract the archive.
     - Run the godot executable, for example double-clicking the "Godot_v3.5.1-stable_win64.exe" file.
 2. Import the project into godot.
@@ -22,15 +23,21 @@ Adding an screenshot or a mockup of your application in action would be nice.
     - Select the new "Browse" option that appears.
     - Navigate to and select an empty folder to install the project.
     - Click "Import & Edit."
-3. Export the project to an executable binary.
-    - In the top-level, select "Project".
+3. Download and install the standard export templates.
+    - In the top-level menu, select "Editor."
+    - Click "Manage Export Templates..."
+    - Click "Download and Install." Total size is 549.4 MB.
+    - After the installation finishes, click "Close."
+4. Export the project to an executable binary.
+    - In the top-level menu, select "Project."
     - Select "Export..."
     - Across from Presets, select "Add."
-    - Choose your operating system (Additional setup may be required).
+    - Choose your operating system.
+        - Additional setup may be required for [macOS](https://docs.godotengine.org/en/3.5/tutorials/export/exporting_for_macos.html), [iOS](https://docs.godotengine.org/en/3.5/tutorials/export/exporting_for_ios.html), or [Android](https://docs.godotengine.org/en/3.5/tutorials/export/exporting_for_android.html).
     - Select "Export Project..."
     - Navigate to select the location and name for the new executable.
     - Click "Save."
-4. Close godot
+5. Close godot.
     - Click "Close."
     - In the top-level menu, select "Scene."
     - Press "Quit."

--- a/code/engine/move/diagonal_negative_move.gd
+++ b/code/engine/move/diagonal_negative_move.gd
@@ -6,10 +6,12 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var max_length
 
 
-func _init(name_):
+func _init(name_, max_length_=-1):
 	name = name_
+	max_length = max_length_
 
 # Validates a line of spaces and adds valid spaces to the list of positions.
 # Arguments:
@@ -17,7 +19,7 @@ func _init(name_):
 # game: The game state information.
 # pos: The original position of the piece.
 # piece: The selected piece's state information.
-func add_pos(positions, game, pos, piece):
+func add_pos(positions, game, pos, _piece):
 	var start: int
 	var end: int
 	var file = pos % game.width
@@ -27,10 +29,10 @@ func add_pos(positions, game, pos, piece):
 	end = pos + 1 + (game.width - 1) * round(min(file, game.height - rank - 1))
 	if start < end:
 		linear.add_pos_linear(positions, start, end, game.width - 1,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)
 	# Check spaces up-right from origin.
 	start = pos - game.width + 1
 	end = pos - 1 - (game.width - 1) * round(min(game.width - file - 1, rank))
 	if start > end:
 		linear.add_pos_linear(positions, start, end, 1 - game.width,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)

--- a/code/engine/move/diagonal_negative_move.gd
+++ b/code/engine/move/diagonal_negative_move.gd
@@ -6,12 +6,17 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var can_capture
+var must_capture
 var max_length
 
 
-func _init(name_, max_length_=-1):
+func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
 	max_length = max_length_
+
 
 # Validates a line of spaces and adds valid spaces to the list of positions.
 # Arguments:
@@ -29,10 +34,10 @@ func add_pos(positions, game, pos, _piece):
 	end = pos + 1 + (game.width - 1) * round(min(file, game.height - rank - 1))
 	if start < end:
 		linear.add_pos_linear(positions, start, end, game.width - 1,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)
 	# Check spaces up-right from origin.
 	start = pos - game.width + 1
 	end = pos - 1 - (game.width - 1) * round(min(game.width - file - 1, rank))
 	if start > end:
 		linear.add_pos_linear(positions, start, end, 1 - game.width,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)

--- a/code/engine/move/diagonal_negative_move.gd
+++ b/code/engine/move/diagonal_negative_move.gd
@@ -11,7 +11,7 @@ var must_capture
 var max_length
 
 
-func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
+func _init(name_ = "diagonal SW-NE", can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
 	can_capture = can_capture_
 	must_capture = must_capture_

--- a/code/engine/move/diagonal_negative_move.gd
+++ b/code/engine/move/diagonal_negative_move.gd
@@ -1,29 +1,13 @@
+extends "res://engine/move/linear_move.gd"
 # DiagonalNegativeMove contains the logic for a move in the negative diagonal (up-right).
 
 
-const linear = preload("res://engine/move/linear_move.gd")
+func _init(name_ = "diagonal SW-NE", can_capture_ = true, must_capture_ = false, max_length_= -1).(
+		name_, can_capture_, must_capture_, max_length_
+):
+	pass
 
 
-# Properties
-var name
-var can_capture
-var must_capture
-var max_length
-
-
-func _init(name_ = "diagonal SW-NE", can_capture_ = true, must_capture_ = false, max_length_= -1):
-	name = name_
-	can_capture = can_capture_
-	must_capture = must_capture_
-	max_length = max_length_
-
-
-# Validates a line of spaces and adds valid spaces to the list of positions.
-# Arguments:
-# positions: The array of positions.
-# game: The game state information.
-# pos: The original position of the piece.
-# piece: The selected piece's state information.
 func add_pos(positions, game, pos, _piece):
 	var start: int
 	var end: int
@@ -33,11 +17,9 @@ func add_pos(positions, game, pos, _piece):
 	start = pos + game.width - 1
 	end = pos + 1 + (game.width - 1) * round(min(file, game.height - rank - 1))
 	if start < end:
-		linear.add_pos_linear(positions, start, end, game.width - 1,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, game.width - 1, game.max_pos, game.pieces)
 	# Check spaces up-right from origin.
 	start = pos - game.width + 1
 	end = pos - 1 - (game.width - 1) * round(min(game.width - file - 1, rank))
 	if start > end:
-		linear.add_pos_linear(positions, start, end, 1 - game.width,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, 1 - game.width, game.max_pos, game.pieces)

--- a/code/engine/move/diagonal_positive_move.gd
+++ b/code/engine/move/diagonal_positive_move.gd
@@ -6,10 +6,12 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var max_length
 
 
-func _init(name_):
+func _init(name_, max_length_=-1):
 	name = name_
+	max_length = max_length_
 
 # Validates a line of spaces and adds valid spaces to the list of positions.
 # Arguments:
@@ -17,7 +19,7 @@ func _init(name_):
 # game: The game state information.
 # pos: The original position of the piece.
 # piece: The selected piece's state information.
-func add_pos(positions, game, pos, piece):
+func add_pos(positions, game, pos, _piece):
 	var start: int
 	var end: int
 	var file = pos % game.width
@@ -27,10 +29,10 @@ func add_pos(positions, game, pos, piece):
 	end = pos + 1 + (game.width + 1) * (round(min(game.width - file, game.height - rank)) - 1)
 	if start < end:
 		linear.add_pos_linear(positions, start, end, game.width + 1,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)
 	# Check spaces up-left from origin.
 	start = pos - game.width - 1
 	end = pos - 1 - (game.width + 1) * (round(min(rank, file)))
 	if start > end:
 		linear.add_pos_linear(positions, start, end, -game.width - 1,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)

--- a/code/engine/move/diagonal_positive_move.gd
+++ b/code/engine/move/diagonal_positive_move.gd
@@ -11,7 +11,7 @@ var must_capture
 var max_length
 
 
-func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
+func _init(name_ = "diagonal NW-SE", can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
 	can_capture = can_capture_
 	must_capture = must_capture_

--- a/code/engine/move/diagonal_positive_move.gd
+++ b/code/engine/move/diagonal_positive_move.gd
@@ -6,12 +6,17 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var can_capture
+var must_capture
 var max_length
 
 
-func _init(name_, max_length_=-1):
+func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
 	max_length = max_length_
+
 
 # Validates a line of spaces and adds valid spaces to the list of positions.
 # Arguments:
@@ -29,10 +34,10 @@ func add_pos(positions, game, pos, _piece):
 	end = pos + 1 + (game.width + 1) * (round(min(game.width - file, game.height - rank)) - 1)
 	if start < end:
 		linear.add_pos_linear(positions, start, end, game.width + 1,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)
 	# Check spaces up-left from origin.
 	start = pos - game.width - 1
 	end = pos - 1 - (game.width + 1) * (round(min(rank, file)))
 	if start > end:
 		linear.add_pos_linear(positions, start, end, -game.width - 1,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)

--- a/code/engine/move/diagonal_positive_move.gd
+++ b/code/engine/move/diagonal_positive_move.gd
@@ -1,29 +1,13 @@
+extends "res://engine/move/linear_move.gd"
 # DiagonalPositiveMove contains the logic for a move in the positive diagonal (down-right).
 
 
-const linear = preload("res://engine/move/linear_move.gd")
+func _init(name_ = "diagonal NW-SE", can_capture_ = true, must_capture_ = false, max_length_= -1).(
+		name_, can_capture_, must_capture_, max_length_
+):
+	pass
 
 
-# Properties
-var name
-var can_capture
-var must_capture
-var max_length
-
-
-func _init(name_ = "diagonal NW-SE", can_capture_ = true, must_capture_ = false, max_length_= -1):
-	name = name_
-	can_capture = can_capture_
-	must_capture = must_capture_
-	max_length = max_length_
-
-
-# Validates a line of spaces and adds valid spaces to the list of positions.
-# Arguments:
-# positions: The array of positions.
-# game: The game state information.
-# pos: The original position of the piece.
-# piece: The selected piece's state information.
 func add_pos(positions, game, pos, _piece):
 	var start: int
 	var end: int
@@ -33,11 +17,9 @@ func add_pos(positions, game, pos, _piece):
 	start = pos + game.width + 1
 	end = pos + 1 + (game.width + 1) * (round(min(game.width - file, game.height - rank)) - 1)
 	if start < end:
-		linear.add_pos_linear(positions, start, end, game.width + 1,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, game.width + 1, game.max_pos, game.pieces)
 	# Check spaces up-left from origin.
 	start = pos - game.width - 1
 	end = pos - 1 - (game.width + 1) * (round(min(rank, file)))
 	if start > end:
-		linear.add_pos_linear(positions, start, end, -game.width - 1,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, -game.width - 1, game.max_pos, game.pieces)

--- a/code/engine/move/forward_diagonal_move.gd
+++ b/code/engine/move/forward_diagonal_move.gd
@@ -1,0 +1,38 @@
+# ForwardDiagonalMove contains the logic for a pawn's basic forward-diagonal
+# moves, which must capture.
+
+
+# Properties
+var name
+var can_capture
+var must_capture
+
+
+func _init(name_ = "forward-diagonal-1 (pawn)", can_capture_ = true, must_capture_ = true):
+	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
+
+# Checks the square that is forward one square, relative to the piece's team.
+# Arguments:
+# positions: The array of positions.
+# game: The game state information.
+# pos: The original position of the piece.
+# piece: The selected piece's state information.
+func add_pos(positions, game, pos, piece):
+	var pieces = game.pieces
+	var base_pos
+	var new_pos
+	# Use piece's team to decide forward-rank direction.
+	base_pos = pos + game.width * (1 if piece.team == game.Team[1] else -1)
+	for i in range(-1, 2, 2):
+		new_pos = base_pos + i 
+		if (
+				new_pos >= 0
+				and new_pos <= game.max_pos
+				and (
+						(pieces.has(new_pos) and can_capture)
+						or (not pieces.has(new_pos) and not must_capture)
+				)
+		):
+			positions.append(new_pos)

--- a/code/engine/move/forward_double_move.gd
+++ b/code/engine/move/forward_double_move.gd
@@ -1,0 +1,41 @@
+# ForwardDoubleMove contains the logic for a pawn's two-space forward-rank move,
+# which must be its first move, and cannot capture.
+
+
+# Properties
+var name
+var can_capture
+var must_capture
+var first_move
+
+
+func _init(name_ = "forward-2 (pawn)", can_capture_ = false, must_capture_ = false, first_move_ = true):
+	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
+	first_move = first_move_
+
+# Checks the two squares rank-forward from the piece, relative to its team.
+# Arguments:
+# positions: The array of positions.
+# game: The game state information.
+# pos: The original position of the piece.
+# piece: The selected piece's state information.
+func add_pos(positions, game, pos, piece):
+	var pieces = game.pieces
+	var new_pos
+	var delta
+	# Use piece's team to decide forward-rank direction.
+	delta = game.width * (1 if piece.team == game.Team[1] else -1)
+	new_pos = pos + 2 * delta
+	if (
+			new_pos >= 0
+			and new_pos <= game.max_pos
+			and not pieces.has(new_pos - delta)
+			and (not piece.has_moved or not first_move)
+			and (
+					(pieces.has(new_pos) and can_capture)
+					or (not pieces.has(new_pos) and not must_capture)
+			)
+	):
+		positions.append(new_pos)

--- a/code/engine/move/forward_move.gd
+++ b/code/engine/move/forward_move.gd
@@ -1,0 +1,34 @@
+# ForwardMove contains the logic for a pawn's basic forward-rank move, which cannot capture.
+
+
+# Properties
+var name
+var can_capture
+var must_capture
+
+
+func _init(name_ = "forward-1 (pawn)", can_capture_ = false, must_capture_ = false):
+	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
+
+# Checks the square that is forward one square, relative to the piece's team.
+# Arguments:
+# positions: The array of positions.
+# game: The game state information.
+# pos: The original position of the piece.
+# piece: The selected piece's state information.
+func add_pos(positions, game, pos, piece):
+	var pieces = game.pieces
+	var new_pos
+	# Use piece's team to decide forward-rank direction.
+	new_pos = pos + game.width * (1 if piece.team == game.Team[1] else -1)
+	if (
+			new_pos >= 0
+			and new_pos <= game.max_pos
+			and (
+					(pieces.has(new_pos) and can_capture)
+					or (not pieces.has(new_pos) and not must_capture)
+			)
+	):
+		positions.append(new_pos)

--- a/code/engine/move/horizontal_move.gd
+++ b/code/engine/move/horizontal_move.gd
@@ -6,12 +6,17 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var can_capture
+var must_capture
 var max_length
 
 
-func _init(name_, max_length_=-1):
+func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
 	max_length = max_length_
+
 
 # Validates a line of spaces and adds valid spaces to the list of positions.
 # Arguments:
@@ -27,10 +32,10 @@ func add_pos(positions, game, pos, _piece):
 	end = game.width * (pos / game.width + 1)
 	if start < end:
 		linear.add_pos_linear(positions, start, end, 1,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)
 	# Check spaces to the left.
 	start = pos - 1
 	end = game.width * (pos / game.width) - 1
 	if start > end:
 		linear.add_pos_linear(positions, start, end, -1,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)

--- a/code/engine/move/horizontal_move.gd
+++ b/code/engine/move/horizontal_move.gd
@@ -1,29 +1,13 @@
+extends "res://engine/move/linear_move.gd"
 # HorizontalMove contains the logic for a move within a rank.
 
 
-const linear = preload("res://engine/move/linear_move.gd")
+func _init(name_ = "left-and-right", can_capture_ = true, must_capture_ = false, max_length_= -1).(
+		name_, can_capture_, must_capture_, max_length_
+):
+	pass
 
 
-# Properties
-var name
-var can_capture
-var must_capture
-var max_length
-
-
-func _init(name_ = "left-and-right", can_capture_ = true, must_capture_ = false, max_length_= -1):
-	name = name_
-	can_capture = can_capture_
-	must_capture = must_capture_
-	max_length = max_length_
-
-
-# Validates a line of spaces and adds valid spaces to the list of positions.
-# Arguments:
-# positions: The array of positions.
-# game: The game state information.
-# pos: The original position of the piece.
-# piece: The selected piece's state information.
 func add_pos(positions, game, pos, _piece):
 	var start
 	var end
@@ -31,11 +15,9 @@ func add_pos(positions, game, pos, _piece):
 	start = pos + 1
 	end = game.width * (pos / game.width + 1)
 	if start < end:
-		linear.add_pos_linear(positions, start, end, 1,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, 1, game.max_pos, game.pieces)
 	# Check spaces to the left.
 	start = pos - 1
 	end = game.width * (pos / game.width) - 1
 	if start > end:
-		linear.add_pos_linear(positions, start, end, -1,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, -1, game.max_pos, game.pieces)

--- a/code/engine/move/horizontal_move.gd
+++ b/code/engine/move/horizontal_move.gd
@@ -6,10 +6,12 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var max_length
 
 
-func _init(name_):
+func _init(name_, max_length_=-1):
 	name = name_
+	max_length = max_length_
 
 # Validates a line of spaces and adds valid spaces to the list of positions.
 # Arguments:
@@ -17,7 +19,7 @@ func _init(name_):
 # game: The game state information.
 # pos: The original position of the piece.
 # piece: The selected piece's state information.
-func add_pos(positions, game, pos, piece):
+func add_pos(positions, game, pos, _piece):
 	var start
 	var end
 	# Check spaces to the right.
@@ -25,10 +27,10 @@ func add_pos(positions, game, pos, piece):
 	end = game.width * (pos / game.width + 1)
 	if start < end:
 		linear.add_pos_linear(positions, start, end, 1,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)
 	# Check spaces to the left.
 	start = pos - 1
 	end = game.width * (pos / game.width) - 1
 	if start > end:
 		linear.add_pos_linear(positions, start, end, -1,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)

--- a/code/engine/move/horizontal_move.gd
+++ b/code/engine/move/horizontal_move.gd
@@ -11,7 +11,7 @@ var must_capture
 var max_length
 
 
-func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
+func _init(name_ = "left-and-right", can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
 	can_capture = can_capture_
 	must_capture = must_capture_

--- a/code/engine/move/king_basic_move.gd
+++ b/code/engine/move/king_basic_move.gd
@@ -1,0 +1,41 @@
+# KingBasicMove contains the logic for a one-tile movement in eight directions.
+
+
+# Cardinal directions
+var directions = [[0, 1], [1,1], [1, 0], [1, -1],
+		[0, -1], [-1, -1], [-1, 0], [-1, 1]]
+
+
+# Properties
+var name
+var can_capture
+var must_capture
+
+
+func _init(name_, can_capture_ = true, must_capture_ = false):
+	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
+
+
+# Validates a line of spaces and adds valid spaces to the list of positions.
+# Arguments:
+# positions: The array of positions.
+# game: The game state information.
+# pos: The original position of the piece.
+# piece: The selected piece's state information.
+func add_pos(positions, game, pos, _piece):
+	var new_pos
+	var pieces = game.pieces
+	for dir in directions:
+		new_pos = pos + dir[0] + dir[1] * game.width
+
+		if (
+			new_pos >= 0
+			and new_pos <= game.max_pos
+			and (
+				(pieces.has(new_pos) and can_capture)
+				or (not pieces.has(new_pos) and not must_capture)
+			)
+		):
+			positions.append(new_pos)

--- a/code/engine/move/king_basic_move.gd
+++ b/code/engine/move/king_basic_move.gd
@@ -12,7 +12,7 @@ var can_capture
 var must_capture
 
 
-func _init(name_, can_capture_ = true, must_capture_ = false):
+func _init(name_ = "1-space 8-directions (king)", can_capture_ = true, must_capture_ = false):
 	name = name_
 	can_capture = can_capture_
 	must_capture = must_capture_

--- a/code/engine/move/knight_move.gd
+++ b/code/engine/move/knight_move.gd
@@ -13,7 +13,7 @@ var can_capture
 var must_capture
 
 
-func _init(name_, can_capture_ = true, must_capture_ = false):
+func _init(name_ = "L-shaped jump (knight)", can_capture_ = true, must_capture_ = false):
 	name = name_
 	can_capture = can_capture_
 	must_capture = must_capture_

--- a/code/engine/move/knight_move.gd
+++ b/code/engine/move/knight_move.gd
@@ -21,8 +21,7 @@ func _init(name_):
 # game: The game state information.
 # pos: The original position of the piece.
 # piece: The selected piece's state information.
-func add_pos(positions, game, pos, piece):
-	var pieces = game.pieces
+func add_pos(positions, game, pos, _piece):
 	for move in movements:
 		for rot in rotations:
 			var new_pos = (
@@ -34,6 +33,5 @@ func add_pos(positions, game, pos, piece):
 			if (
 					new_pos >= 0
 					and new_pos <= game.max_pos
-					and (not pieces.has(new_pos) or pieces[new_pos].team != piece.team)
 			):
 				positions.append(new_pos)

--- a/code/engine/move/knight_move.gd
+++ b/code/engine/move/knight_move.gd
@@ -11,15 +11,12 @@ var rotations = [[1, 0, 0, 1], [0, -1, 1, 0], [-1, 0, 0, -1], [0, 1, -1, 0]]
 var name
 var can_capture
 var must_capture
-var max_length
 
 
-func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
+func _init(name_, can_capture_ = true, must_capture_ = false):
 	name = name_
 	can_capture = can_capture_
 	must_capture = must_capture_
-	max_length = max_length_
-
 
 # Validates squares for a knight's move and adds them to the list of positions.
 # Arguments:

--- a/code/engine/move/knight_move.gd
+++ b/code/engine/move/knight_move.gd
@@ -9,10 +9,16 @@ var rotations = [[1, 0, 0, 1], [0, -1, 1, 0], [-1, 0, 0, -1], [0, 1, -1, 0]]
 
 # Properties
 var name
+var can_capture
+var must_capture
+var max_length
 
 
-func _init(name_):
+func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
+	max_length = max_length_
 
 
 # Validates squares for a knight's move and adds them to the list of positions.
@@ -22,6 +28,7 @@ func _init(name_):
 # pos: The original position of the piece.
 # piece: The selected piece's state information.
 func add_pos(positions, game, pos, _piece):
+	var pieces = game.pieces
 	for move in movements:
 		for rot in rotations:
 			var new_pos = (
@@ -33,5 +40,9 @@ func add_pos(positions, game, pos, _piece):
 			if (
 					new_pos >= 0
 					and new_pos <= game.max_pos
+					and (
+							(pieces.has(new_pos) and can_capture)
+							or (not pieces.has(new_pos) and not must_capture)
+					)
 			):
 				positions.append(new_pos)

--- a/code/engine/move/knight_move.gd
+++ b/code/engine/move/knight_move.gd
@@ -1,0 +1,39 @@
+# LinearMove contains the logic for a knight's movements.
+
+
+# Movement vectors.
+var movements = [[1, 2], [-1, 2]]
+# Cardinal rotations
+var rotations = [[1, 0, 0, 1], [0, -1, 1, 0], [-1, 0, 0, -1], [0, 1, -1, 0]]
+
+
+# Properties
+var name
+
+
+func _init(name_):
+	name = name_
+
+
+# Validates squares for a knight's move and adds them to the list of positions.
+# Arguments:
+# positions: The array of positions.
+# game: The game state information.
+# pos: The original position of the piece.
+# piece: The selected piece's state information.
+func add_pos(positions, game, pos, piece):
+	var pieces = game.pieces
+	for move in movements:
+		for rot in rotations:
+			var new_pos = (
+					pos
+					+ move[0] * rot[0]
+					+ move[1] * rot[1]
+					+ (move[0] * rot[2] + move[1] * rot[3]) * game.width
+			)
+			if (
+					new_pos >= 0
+					and new_pos <= game.max_pos
+					and (not pieces.has(new_pos) or pieces[new_pos].team != piece.team)
+			):
+				positions.append(new_pos)

--- a/code/engine/move/linear_move.gd
+++ b/code/engine/move/linear_move.gd
@@ -7,19 +7,22 @@
 # end: The space to stop at, but not check.
 # step: The index length between spaces.
 # max_pos: The maximum board position.
-# team: The piece's team.
+# max_length: The maximum length of the movement. -1 := no maximum length.
 # pieces: The map of board positions and chess pieces.
-static func add_pos_linear(positions, start, end, step, max_pos, team, pieces):
+static func add_pos_linear(positions, start, end, step, max_pos, max_length, pieces):
 	# Check spaces in one direction from the origin.
+	var length = max_length
 	for new_pos in range(start, end, step):
 		if not pieces.has(new_pos):
 			# Add position if it is inbounds.
 			if new_pos >= 0 and new_pos <= max_pos:
 				positions.append(new_pos)
 		else:
-			# If the piece is on the opposing team, then add position if the
-			# distance is a multiple of step.
-			if pieces[new_pos].team != team:
-				positions.append(new_pos)
+			# Add position of a piece.
+			positions.append(new_pos)
 			# Exit loop because pieces block further movement.
+			break
+		length -= 1
+		if length == 0:
+			# Exit loop if maximum travel distance is reached.
 			break

--- a/code/engine/move/linear_move.gd
+++ b/code/engine/move/linear_move.gd
@@ -1,6 +1,30 @@
 # LinearMove contains the logic for a movement in an unobstructed straight line.
 
 
+# Properties
+var name
+var can_capture
+var must_capture
+var max_length
+
+
+func _init(name_, can_capture_, must_capture_, max_length_):
+	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
+	max_length = max_length_
+
+
+# Validates a line of spaces and adds valid spaces to the list of positions.
+# Arguments:
+# positions: The array of positions.
+# game: The game state information.
+# pos: The original position of the piece.
+# piece: The selected piece's state information.
+func add_pos(_positions, _game, _pos, _piece):
+	pass
+
+
 # Validates a line of spaces in one direction, and adds valid spaces to the list of positions.
 # Arguments:
 # positions: The array of positions.
@@ -8,12 +32,8 @@
 # end: The space to stop at, but not check.
 # step: The index length between spaces.
 # max_pos: The maximum board position.
-# max_length: The maximum length of the movement. -1 := no maximum length.
-# can_capture: Flag for whether or not the move can capture.
-# must_capture: Flag for whether or not the move must capture.
 # pieces: The map of board positions and chess pieces.
-static func add_pos_linear(positions, start, end, step, max_pos,
-		max_length, can_capture, must_capture, pieces):
+func add_pos_linear(positions, start, end, step, max_pos, pieces):
 	# Check spaces in one direction from the origin.
 	var length = max_length
 	for new_pos in range(start, end, step):

--- a/code/engine/move/linear_move.gd
+++ b/code/engine/move/linear_move.gd
@@ -1,5 +1,6 @@
 # LinearMove contains the logic for a movement in an unobstructed straight line.
 
+
 # Validates a line of spaces in one direction, and adds valid spaces to the list of positions.
 # Arguments:
 # positions: The array of positions.
@@ -8,17 +9,20 @@
 # step: The index length between spaces.
 # max_pos: The maximum board position.
 # max_length: The maximum length of the movement. -1 := no maximum length.
+# can_capture: Flag for whether or not the move can capture.
+# must_capture: Flag for whether or not the move must capture.
 # pieces: The map of board positions and chess pieces.
-static func add_pos_linear(positions, start, end, step, max_pos, max_length, pieces):
+static func add_pos_linear(positions, start, end, step, max_pos,
+		max_length, can_capture, must_capture, pieces):
 	# Check spaces in one direction from the origin.
 	var length = max_length
 	for new_pos in range(start, end, step):
-		if not pieces.has(new_pos):
+		if not pieces.has(new_pos) and not must_capture:
 			# Add position if it is inbounds.
 			if new_pos >= 0 and new_pos <= max_pos:
 				positions.append(new_pos)
-		else:
-			# Add position of a piece.
+		elif pieces.has(new_pos) and can_capture:
+			# Add position of an occupying piece.
 			positions.append(new_pos)
 			# Exit loop because pieces block further movement.
 			break

--- a/code/engine/move/vertical_move.gd
+++ b/code/engine/move/vertical_move.gd
@@ -1,28 +1,13 @@
+extends "res://engine/move/linear_move.gd"
 # VerticalMove contains the logic for a move within a file.
 
 
-const linear = preload("res://engine/move/linear_move.gd")
+func _init(name_ = "up-and-down", can_capture_ = true, must_capture_ = false, max_length_= -1).(
+		name_, can_capture_, must_capture_, max_length_
+):
+	pass
 
 
-# Properties
-var name
-var can_capture
-var must_capture
-var max_length
-
-
-func _init(name_ = "up-and-down", can_capture_ = true, must_capture_ = false, max_length_= -1):
-	name = name_
-	can_capture = can_capture_
-	must_capture = must_capture_
-	max_length = max_length_
-
-# Validates a line of spaces and adds valid spaces to the list of positions.
-# Arguments:
-# positions: The array of positions.
-# game: The game state information.
-# pos: The original position of the piece.
-# piece: The selected piece's state information.
 func add_pos(positions, game, pos, _piece):
 	var start
 	var end
@@ -30,11 +15,9 @@ func add_pos(positions, game, pos, _piece):
 	start = pos + game.width
 	end = game.max_pos + 1
 	if start < end:
-		linear.add_pos_linear(positions, start, end, game.width,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, game.width, game.max_pos, game.pieces)
 	# Check spaces above.
 	start = pos - game.width
 	end = pos % game.width - 1
 	if start > end:
-		linear.add_pos_linear(positions, start, end, -game.width,
-				game.max_pos, max_length, can_capture, must_capture, game.pieces)
+		add_pos_linear(positions, start, end, -game.width, game.max_pos, game.pieces)

--- a/code/engine/move/vertical_move.gd
+++ b/code/engine/move/vertical_move.gd
@@ -6,11 +6,12 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var max_length
 
 
-func _init(name_):
+func _init(name_, max_length_=-1):
 	name = name_
-
+	max_length = max_length_
 
 # Validates a line of spaces and adds valid spaces to the list of positions.
 # Arguments:
@@ -18,7 +19,7 @@ func _init(name_):
 # game: The game state information.
 # pos: The original position of the piece.
 # piece: The selected piece's state information.
-func add_pos(positions, game, pos, piece):
+func add_pos(positions, game, pos, _piece):
 	var start
 	var end
 	# Check spaces below.
@@ -26,10 +27,10 @@ func add_pos(positions, game, pos, piece):
 	end = game.max_pos + 1
 	if start < end:
 		linear.add_pos_linear(positions, start, end, game.width,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)
 	# Check spaces above.
 	start = pos - game.width
 	end = pos % game.width - 1
 	if start > end:
 		linear.add_pos_linear(positions, start, end, -game.width,
-				game.max_pos, piece.team, game.pieces)
+				game.max_pos, max_length, game.pieces)

--- a/code/engine/move/vertical_move.gd
+++ b/code/engine/move/vertical_move.gd
@@ -11,7 +11,7 @@ var must_capture
 var max_length
 
 
-func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
+func _init(name_ = "up-and-down", can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
 	can_capture = can_capture_
 	must_capture = must_capture_
@@ -31,10 +31,10 @@ func add_pos(positions, game, pos, _piece):
 	end = game.max_pos + 1
 	if start < end:
 		linear.add_pos_linear(positions, start, end, game.width,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)
 	# Check spaces above.
 	start = pos - game.width
 	end = pos % game.width - 1
 	if start > end:
 		linear.add_pos_linear(positions, start, end, -game.width,
-				game.max_pos, max_length, game.pieces)
+				game.max_pos, max_length, can_capture, must_capture, game.pieces)

--- a/code/engine/move/vertical_move.gd
+++ b/code/engine/move/vertical_move.gd
@@ -6,11 +6,15 @@ const linear = preload("res://engine/move/linear_move.gd")
 
 # Properties
 var name
+var can_capture
+var must_capture
 var max_length
 
 
-func _init(name_, max_length_=-1):
+func _init(name_, can_capture_ = true, must_capture_ = false, max_length_= -1):
 	name = name_
+	can_capture = can_capture_
+	must_capture = must_capture_
 	max_length = max_length_
 
 # Validates a line of spaces and adds valid spaces to the list of positions.

--- a/code/engine/piece/bishop.gd
+++ b/code/engine/piece/bishop.gd
@@ -2,11 +2,11 @@ extends "res://engine/piece/custom_piece.gd"
 # Bishop contains the bishop chess piece logic.
 
 
-var DPosMove = preload("res://engine/move/diagonal_positive_move.gd")
-var DNegMove = preload("res://engine/move/diagonal_negative_move.gd")
+var DiagonalPositiveMove = preload("res://engine/move/diagonal_positive_move.gd")
+var DiagonalNegativeMove = preload("res://engine/move/diagonal_negative_move.gd")
 
 
 func _init():
 	# Add the default bishop moves.
-	add_move(DPosMove.new("diagonal NW-SE"))
-	add_move(DNegMove.new("diagonal SW-NE"))
+	add_move(DiagonalPositiveMove.new())
+	add_move(DiagonalNegativeMove.new())

--- a/code/engine/piece/custom_piece.gd
+++ b/code/engine/piece/custom_piece.gd
@@ -24,6 +24,8 @@ func calc_moves(pos, piece, game):
 func add_move(new_move):
 	if (new_move.has_method("add_pos")
 			and "name" in new_move
+			and "can_capture" in new_move
+			and "must_capture" in new_move
 			and _find_move_name(new_move.name) == -1
 	):
 		move_list.append(new_move)

--- a/code/engine/piece/custom_piece.gd
+++ b/code/engine/piece/custom_piece.gd
@@ -28,6 +28,7 @@ func add_move(new_move):
 	):
 		move_list.append(new_move)
 		return true
+	push_error("A move with name \"" + new_move.name + "\" already exists.")
 	return false
 
 # Removes a move with a particular name from the move list.

--- a/code/engine/piece/custom_piece.gd
+++ b/code/engine/piece/custom_piece.gd
@@ -24,8 +24,6 @@ func calc_moves(pos, piece, game):
 func add_move(new_move):
 	if (new_move.has_method("add_pos")
 			and "name" in new_move
-			and "can_capture" in new_move
-			and "must_capture" in new_move
 			and _find_move_name(new_move.name) == -1
 	):
 		move_list.append(new_move)

--- a/code/engine/piece/custom_piece.gd
+++ b/code/engine/piece/custom_piece.gd
@@ -23,8 +23,8 @@ func calc_moves(pos, piece, game):
 #	Returns true if successful.
 func add_move(new_move):
 	if (new_move.has_method("add_pos")
-			and new_move.has_method("getName")
-			and _find_move_name(new_move.getName() != -1)
+			and "name" in new_move
+			and _find_move_name(new_move.name) == -1
 	):
 		move_list.append(new_move)
 		return true
@@ -44,7 +44,7 @@ func remove_move(name):
 func get_move_names():
 	var move_names = []
 	for move in move_list:
-		move_names.append(move.getName())
+		move_names.append(move.name)
 	return move_names
 
 # Checks if a particular name exists in the move list.
@@ -52,6 +52,6 @@ func get_move_names():
 #	Returns its position if found, otherwise -1.
 func _find_move_name(name):
 	for i in move_list.size():
-		if move_list[i].getName == name:
+		if move_list[i].name == name:
 			return i
 	return -1

--- a/code/engine/piece/king.gd
+++ b/code/engine/piece/king.gd
@@ -1,42 +1,12 @@
+extends "res://engine/piece/custom_piece.gd"
 # King contains the king chess piece logic.
 
 
-# Cardinal directions
-var directions = [[0, 1], [1,1], [1, 0], [1, -1],
-		[0, -1], [-1, -1], [-1, 0], [-1, 1]]
+var KingBasicMove = preload("res://engine/move/king_basic_move.gd")
 
 
-# Given game state information, this function returns a list of potentially valid new positions.
-# Arguments:
-# pos: The original position. of the piece.
-# piece: The piece's state information.
-# game: The game's state information.
-# Return:
-#	Returns an array of positions.
-func calc_moves(pos, piece, game):
-	var positions = []
+func _init():
+	# Add the default king moves.
+	add_move(KingBasicMove.new("1-tile 8-directions"))
 
-	# Get basic movements.
-	for dir in directions:
-		var new_pos = pos + dir[0] + dir[1] * game.get("width")
-		_add_move(positions, new_pos, piece.team, game.get("max_pos"), game.pieces)
-
-	# TODO Implement castling validation.
-
-	return positions
-
-
-# Checks if a space can be moved into, and if so, adds it to the list.
-# Arguments:
-# positions: The array of positions to append to.
-# new_pos: The prospective position.
-# max_pos: The maximum board position.
-# team: The piece's team.
-# pieces: The map of board positions and chess pieces.
-func _add_move(positions, new_pos, max_pos, team, pieces):
-	if (
-			new_pos >= 0
-			and new_pos <= max_pos
-			and (not pieces.has(new_pos) or pieces[new_pos].team != team)
-	):
-		positions.append(new_pos)
+	# TODO Add kingside and queenside castling validation.

--- a/code/engine/piece/king.gd
+++ b/code/engine/piece/king.gd
@@ -7,6 +7,6 @@ var KingBasicMove = preload("res://engine/move/king_basic_move.gd")
 
 func _init():
 	# Add the default king moves.
-	add_move(KingBasicMove.new("1-tile 8-directions"))
+	add_move(KingBasicMove.new())
 
 	# TODO Add kingside and queenside castling validation.

--- a/code/engine/piece/knight.gd
+++ b/code/engine/piece/knight.gd
@@ -1,33 +1,10 @@
-# Knight contains the knight chess piece logic.
+extends "res://engine/piece/custom_piece.gd"
+# Knight stores the knight chess piece logic.
 
 
-var movements = [[1, 2], [-1, 2]]
-# Cardinal rotations
-var rotations = [[1, 0, 0, 1], [0, -1, 1, 0], [-1, 0, 0, -1], [0, 1, -1, 0]]
+var KnightMove = preload("res://engine/move/knight_move.gd")
 
 
-# Given game state information, this function returns a list of potentially valid new positions.
-# Arguments:
-# pos: The original position. of the piece.
-# piece: The piece's state information.
-# game: The game's state information.
-# Return:
-#	Returns an array of positions.
-func calc_moves(pos, piece, game):
-	var positions = []
-	var pieces = game.pieces
-	for move in movements:
-		for rot in rotations:
-			var new_pos = (
-					pos
-					+ move[0] * rot[0]
-					+ move[1] * rot[1]
-					+ (move[0] * rot[2] + move[1] * rot[3]) * game.get("width")
-			)
-			if (
-					new_pos >= 0
-					and new_pos <= game.get("max_pos")
-					and (not pieces.has(new_pos) or pieces[new_pos].team != piece.team)
-			):
-				positions.append(new_pos)
-	return positions
+func _init():
+	# Add the default knight moves.
+	add_move(KnightMove.new("knight jump"))

--- a/code/engine/piece/knight.gd
+++ b/code/engine/piece/knight.gd
@@ -7,4 +7,4 @@ var KnightMove = preload("res://engine/move/knight_move.gd")
 
 func _init():
 	# Add the default knight moves.
-	add_move(KnightMove.new("knight jump"))
+	add_move(KnightMove.new())

--- a/code/engine/piece/pawn.gd
+++ b/code/engine/piece/pawn.gd
@@ -1,50 +1,14 @@
+extends "res://engine/piece/custom_piece.gd"
 # Pawn contains the pawn chess piece logic.
 
 
-# Given game state information, this function returns a list of potentially valid new positions.
-# Arguments:
-# pos: The original position. of the piece.
-# piece: The piece's state information.
-# game: The game's state information.
-# Return:
-#	Returns an array of positions.
-func calc_moves(pos, piece, game):
-	var positions = []
-	var sgn = 1 if piece.team == game.Team[1] else -1
-	var new_pos
-
-	# Get forward movements.
-	new_pos = pos + sgn * game.get("width")
-	_add_move(positions, new_pos, game.get("max_pos"), game.pieces)
-	if not piece.has_moved:
-		_add_move(positions, new_pos + sgn * game.get("width"), game.get("max_pos"), game.pieces)
-	# Get diagonal captures.
-	_add_capture(positions, new_pos + 1, piece, game.pieces)
-	_add_capture(positions, new_pos -1, piece, game.pieces)
-
-	# TODO Implement en passant validation using prev_move.
-	return positions
-	pass
+var ForwardMove = preload("res://engine/move/forward_move.gd")
+var ForwardDiagonalMove = preload("res://engine/move/forward_diagonal_move.gd")
+var ForwardDoubleMove = preload("res://engine/move/forward_double_move.gd")
 
 
-# Checks if a space is unoccupied, and if so, adds it to the list of positions.
-# Arguments:
-# positions: The list of positions.
-# new_pos: The prospective position.
-# max_pos: The maximum position.
-# board_map: The map of board positions and chess pieces.
-func _add_move(positions, new_pos, max_pos, pieces):
-	if not pieces.has(new_pos) and new_pos >= 0 and new_pos <= max_pos:
-		positions.append(new_pos)
-
-
-# Checks if a space is occupied and can be captured, and if so, adds it to the
-# list of positions.
-# Arguments:
-# positions: The list of positions.
-# new_pos: The prospective position.
-# piece: The state of the moving piece.
-# board: The map of board positions and chess pieces.
-func _add_capture(positions, new_pos, piece, pieces):
-	if pieces.has(new_pos) and pieces[new_pos].team != piece.team:
-		positions.append(new_pos)
+func _init():
+	# Add the default pawn moves.
+	add_move(ForwardMove.new())
+	add_move(ForwardDiagonalMove.new())
+	add_move(ForwardDoubleMove.new())

--- a/code/engine/piece/queen.gd
+++ b/code/engine/piece/queen.gd
@@ -2,15 +2,15 @@ extends "res://engine/piece/custom_piece.gd"
 # Queen contains the queen chess piece logic.
 
 
-var HMove = preload("res://engine/move/horizontal_move.gd")
-var VMove = preload("res://engine/move/vertical_move.gd")
-var DPosMove = preload("res://engine/move/diagonal_positive_move.gd")
-var DNegMove = preload("res://engine/move/diagonal_negative_move.gd")
+var HorizontalMove = preload("res://engine/move/horizontal_move.gd")
+var VerticalMove = preload("res://engine/move/vertical_move.gd")
+var DiagonalPositiveMove = preload("res://engine/move/diagonal_positive_move.gd")
+var DiagonalNegativeMove = preload("res://engine/move/diagonal_negative_move.gd")
 
 
 func _init():
 	# Add the default queen moves.
-	add_move(HMove.new("horizontal"))
-	add_move(VMove.new("vertical"))
-	add_move(DPosMove.new("diagonal NW-SE"))
-	add_move(DNegMove.new("diagonal SW-NE"))
+	add_move(HorizontalMove.new())
+	add_move(VerticalMove.new())
+	add_move(DiagonalPositiveMove.new())
+	add_move(DiagonalNegativeMove.new())

--- a/code/engine/piece/rook.gd
+++ b/code/engine/piece/rook.gd
@@ -2,11 +2,11 @@ extends "res://engine/piece/custom_piece.gd"
 # Rook stores the rook chess piece logic.
 
 
-var HMove = preload("res://engine/move/horizontal_move.gd")
-var VMove = preload("res://engine/move/vertical_move.gd")
+var HorizontalMove = preload("res://engine/move/horizontal_move.gd")
+var VerticalMove = preload("res://engine/move/vertical_move.gd")
 
 
 func _init():
 	# Add the default rook moves.
-	add_move(HMove.new("horizontal"))
-	add_move(VMove.new("vertical"))
+	add_move(HorizontalMove.new())
+	add_move(VerticalMove.new())


### PR DESCRIPTION
Knight, Pawn, and King have been converted into customizable pieces.
All chess piece classes now extend CustomPiece/custom_piece.gd.
Factored basic chess moves out of the chess piece classes and into individual moves.

Chess pieces should now be modifiable at run-time to have a different collection of moves that can be instantiated with different parameters than normal.

Currently, the parameters common to all moves are:
name: String - This is used to identify an instance of a move.
can_capture: boolean - If true, then occupied positions can be added.
must_capture: boolean - If true, then only occupied positions can be added.

If we create a menu for customizing moves, we can use `"property_name" in object` to check one parameter,  or `get_script_property_list()`, `get_property_list()` (or an override of either) to get a list, then use `object.set("property_name", value)` or similar to modify it.